### PR TITLE
Addresses broken PostGIS support.

### DIFF
--- a/django_db_geventpool/backends/postgresql_psycopg2/base.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/base.py
@@ -144,6 +144,8 @@ class DatabaseWrapperMixin16(object):
         return self.connection
 
     def get_connection_params(self):
+        if not hasattr(self, 'pool'):
+            self.settings_dict.get('OPTIONS', {}).pop('MAX_CONNS', None)
         conn_params = super(DatabaseWrapperMixin16, self).get_connection_params()
         if 'MAX_CONNS' in self.settings_dict['OPTIONS']:
             conn_params['MAX_CONNS'] = self.settings_dict['OPTIONS']['MAX_CONNS']


### PR DESCRIPTION
Please note - this is **untested**. Also, the changes were only to the 1.6 backend only; I do not know if the 1.5 backend needs adjustment. I'm not sure if the fixes I've applied are the best approach, but they appear to work. Please read on for more details.

When using PostGIS pooling backend, PostGIS opens temporary connections to the DB to query PostGIS versions - this happens during the `__init__()` of `DatabaseWrapperMixin16` when calling its `super`. Due to the class/mixin inheritance, it's using the new `get_new_connection` and `close` methods from `DatabaseWrapperMixin16`, but `self.pool` isn't initialized yet.

This commit addresses this scenario - it is largely UNTESTED however. I know that `manage.py runserver` actually runs now with PostGIS backend.

Also - `SOUTH_DATABASE_ADAPTERS = {'default':'south.db.postgresql_psycopg2'}` is needed in your settings.py when using the PostGIS backend.
