### PR TITLE
self.pool must exist prior to the super constructor running

### DIFF
--- a/django_db_geventpool/backends/postgresql_psycopg2/base.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/base.py
@@ -30,8 +30,8 @@ connection_pools_lock = Semaphore(value=1)
 
 class DatabaseWrapperMixin15(object):
     def __init__(self, *args, **kwargs):
-        super(DatabaseWrapperMixin15, self).__init__(*args, **kwargs)
         self._pool = None
+        super(DatabaseWrapperMixin15, self).__init__(*args, **kwargs)
         self.creation = DatabaseCreation(self)
 
     @property
@@ -130,8 +130,8 @@ class DatabaseWrapperMixin15(object):
 
 class DatabaseWrapperMixin16(object):
     def __init__(self, *args, **kwargs):
-        super(DatabaseWrapperMixin16, self).__init__(*args, **kwargs)
         self._pool = None
+        super(DatabaseWrapperMixin16, self).__init__(*args, **kwargs)
         self.creation = DatabaseCreation(self)
 
     @property


### PR DESCRIPTION
The postgis constructor in Django in some cases attempts to establish a connection to the postgres server to establish the version number etc. Therefore get_new_connection must work correctly before this constructor runs. See the original change to make this work: 71d97a6335b080a45fe5b7168f23a91988654278

```
 File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/db/__init__.py", line 40, in __getattr__
    return getattr(connections[DEFAULT_DB_ALIAS], item)
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/db/utils.py", line 243, in __getitem__
    conn = backend.DatabaseWrapper(db, alias)
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/transaction_hooks/mixin.py", line 23, in __init__
    super(TransactionHooksDatabaseWrapperMixin, self).__init__(*a, **kw)
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django_db_geventpool/backends/postgresql_psycopg2/base.py", line 133, in __init__
    super(DatabaseWrapperMixin16, self).__init__(*args, **kwargs)
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/contrib/gis/db/backends/postgis/base.py", line 14, in __init__
    self.ops = PostGISOperations(self)
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/contrib/gis/db/backends/postgis/operations.py", line 166, in __init__
    if self.spatial_version < (1, 3, 4):
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/utils/functional.py", line 55, in __get__
    res = instance.__dict__[self.func.__name__] = self.func(instance)
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/contrib/gis/db/backends/postgis/operations.py", line 260, in spatial_version
    vtup = self.postgis_version_tuple()
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/contrib/gis/db/backends/postgis/operations.py", line 434, in postgis_version_tuple
    version = self.postgis_lib_version()
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/contrib/gis/db/backends/postgis/operations.py", line 414, in postgis_lib_version
    return self._get_postgis_func('postgis_lib_version')
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/contrib/gis/db/backends/postgis/operations.py", line 404, in _get_postgis_func
    with self.connection.temporary_connection() as cursor:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/db/backends/__init__.py", line 543, in temporary_connection
    cursor = self.cursor()
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/db/backends/__init__.py", line 165, in cursor
    cursor = self.make_debug_cursor(self._cursor())
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/db/backends/__init__.py", line 138, in _cursor
    self.ensure_connection()
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/db/backends/__init__.py", line 133, in ensure_connection
    self.connect()
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/transaction_hooks/mixin.py", line 75, in connect
    super(TransactionHooksDatabaseWrapperMixin, self).connect(*a, **kw)
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django/db/backends/__init__.py", line 122, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django_db_geventpool/backends/postgresql_psycopg2/base.py", line 153, in get_new_connection
    self.connection = self.pool.get()
  File "/Users/rajiv/Code/zdiscover16/.venv/lib/python2.7/site-packages/django_db_geventpool/backends/postgresql_psycopg2/base.py", line 139, in pool
    if self._pool is not None:
AttributeError: 'DatabaseWrapper' object has no attribute '_pool'
```
