### PR TITLE
Add import for eventlet workers to README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,12 @@ Patch psycopg2
 --------------
 
 Before using the pool, psycopg2 must be patched with psycogreen, if you are using `gunicorn webserver <http://www.gunicorn.org/>`_,
-a good place is the `post_fork()` function at the config file
+a good place is the [`post_fork()`](http://docs.gunicorn.org/en/latest/settings.html#post-fork) function at the config file:
 
 .. code:: python
 
-   from psycogreen.gevent import patch_psycopg
+   from psycogreen.gevent import patch_psycopg     # use this if you use gevent workers
+   from psycogreen.eventlet import patch_psycopg   # use this if you use eventlet workers
 
    def post_fork(server, worker):
        patch_psycopg()


### PR DESCRIPTION
This PR adds `from psycogreen.eventlet import patch_psycopg` to the example code in the README for those whom use `eventlet` for async workers in Gunicorn.