### PR TITLE
PyPy compatibility by requiring psycopg2cffi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - DJANGO_VERSION=1.10
 install:
     - pip install django==$DJANGO_VERSION
-    - pip install psycopg2
     - pip install gevent
     - python setup.py -q install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
     - '2.7'
+    - 'pypy'
 env:
     - DJANGO_VERSION=1.5.10
     - DJANGO_VERSION=1.6.11

--- a/runtests.py
+++ b/runtests.py
@@ -3,6 +3,12 @@ import sys
 import gevent.monkey
 gevent.monkey.patch_all()
 
+try:
+    from psycopg2cffi import compat
+    compat.register()
+except ImportError:
+    pass
+
 import psycogreen.gevent
 psycogreen.gevent.patch_psycopg()
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
     version='1.21',
     install_requires=[
         'django>=1.5',
-        'psycopg2>=2.5.1',
+        'psycopg2>=2.5.1;platform_python_implementation != "PyPy"',
+        'psycopg2cffi>=2.7;platform_python_implementation == "PyPy"',
         'psycogreen>=1.0'],
     url='https://github.com/jneight/django-db-geventpool',
     description='Add a DB connection pool using gevent to django',


### PR DESCRIPTION
django-db-geventpool currently requires psycopg2 >= 2.5.1

https://github.com/jneight/django-db-geventpool/blob/d346b14a920a17ea1a87c36156216f374876841f/setup.py#L8-L11

psycopg2 [does not work under pypy](https://bitbucket.org/pypy/compatibility/wiki/psycopg2), but there is [psycopg2cffi](https://pypi.python.org/pypi/psycopg2cffi) which provides a compatible implementation.

This pull request uses the feature introduced in [PEP 508](https://www.python.org/dev/peps/pep-0508/) to distinguish the requirements based on the python implementation, so that psycopg2cffi is required under pypy, and psycopg2 is required otherwise.