### PR TITLE
Add Support for Python 3 and Django 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ python:
 env:
     - DJANGO_VERSION=1.8.18
     - DJANGO_VERSION=1.11.8
+matrix:
+    allow_failures:  # allow failures for non-released versions
+        - python: '3.7-dev'
+        - python: 'nightly'
 install:
     - pip install django==$DJANGO_VERSION
     - pip install gevent

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: python
 python:
     - '2.7'
     - 'pypy'
+    - '3.5'
+    - '3.5-dev'
+    - '3.6'
+    - '3.6-dev'
+    - '3.7-dev'
+    - 'nightly'
+    - 'pypy3'
 env:
     - DJANGO_VERSION=1.5.10
     - DJANGO_VERSION=1.6.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,8 @@ python:
     - 'nightly'
     - 'pypy3'
 env:
-    - DJANGO_VERSION=1.5.10
-    - DJANGO_VERSION=1.6.11
-    - DJANGO_VERSION=1.7
-    - DJANGO_VERSION=1.8
-    - DJANGO_VERSION=1.9
-    - DJANGO_VERSION=1.10
+    - DJANGO_VERSION=1.8.18
+    - DJANGO_VERSION=1.11.8
 install:
     - pip install django==$DJANGO_VERSION
     - pip install gevent

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,16 @@ python:
 env:
     - DJANGO_VERSION=1.8.18
     - DJANGO_VERSION=1.11.8
+    - DJANGO_VERSION=2.0
 matrix:
     allow_failures:  # allow failures for non-released versions
         - python: '3.7-dev'
         - python: 'nightly'
+    exclude:  # Django 2 does not support Python 2.x
+        - python: '2.7'
+          env: DJANGO_VERSION=2.0
+        - python: 'pypy'
+          env: DJANGO_VERSION=2.0
 install:
     - pip install django==$DJANGO_VERSION
     - pip install gevent


### PR DESCRIPTION
With this pull request tests will
* not be run anymore on unsupported Django versions (1.5, 1.6, 1.7, 1.9, and 1.10)
* be run on the latest supported versions (1.8, 1.11, 2.0)
* be run with Python 2.7 and 3.5-3.7, and will be allowed to fail on non-released versions
