### PR TITLE
Correct connection cleanup after disabling autocommit with transaction.setautocommit(False)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0
+
+- Correct connection cleanup after disabling autocommit with `transaction.setautocommit(False)`
+
 ## 3.0.1
 
 - Fix setup.py UnicodeDecodeError when installing with python 3.6

--- a/django_db_geventpool/backends/postgresql_psycopg2/base.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/base.py
@@ -194,6 +194,9 @@ class DatabaseWrapperMixin16(object):
         if self.connection.closed:
             self.pool.closeall()
         else:
+            if self.connection.get_transaction_status() == psycopg2.extensions.TRANSACTION_STATUS_INTRANS:
+                self.connection.rollback()
+                self.connection.autocommit = True
             with self.wrap_database_errors:
                 self.pool.put(self.connection)
         self.connection = None

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def long_description():
 
 setup(
     name='django-db-geventpool',
-    version='3.0.1',
+    version='3.1.0',
     install_requires=[
         'django>=1.5',
         'psycogreen>=1.0',


### PR DESCRIPTION
I ran into a case where a developer wasn't using `transaction.atomic` but instead did `transaction.set_autocommit(False)` without changing the value back to `True`.

This returned the connection to the pool with autocommit disabled and subsequent checkouts of the connection from the pool lead to errors like the following:
* `ProgrammingError: set_session cannot be used inside a transaction`
* `cannot TRUNCATE "xxx" because it has pending trigger events`

We of course corrected our code to use `transaction.atomic` but since the cause of this issue is so hard to spot I decided to also prevent this from happening in the pooler.