### PR TITLE
Pool improvements and celery compat

### DIFF
--- a/django_db_geventpool/backends/postgresql_psycopg2/base.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/base.py
@@ -75,6 +75,10 @@ class DatabaseWrapperMixin(object):
         finally:
             self.set_clean()
 
+    def close_if_unusable_or_obsolete(self):
+        # Always close the connection because it's not (usually) really being closed.
+        self.close()
+
     def _close(self):
         if self.connection.closed:
             self.pool.closeall()

--- a/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
@@ -52,6 +52,7 @@ class DatabaseConnectionPool(object):
     def put(self, item):
         try:
             self.pool.put(item, timeout=2)
+            logger.debug("DB connection returned")
         except queue.Full:
             item.close()
 
@@ -66,6 +67,7 @@ class DatabaseConnectionPool(object):
             except Exception:
                 continue
         self.size = 0
+        logger.debug("DB connections all closed")
 
 
 class PostgresConnectionPool(DatabaseConnectionPool):


### PR DESCRIPTION
So this has two main fixes, the first is supporting `close_if_unusable_or_obsolete` as an alias for `close` since we don't actually care about over-closing connections. That fixes things with current Celery (though master of Celery did fix this by reverting the call on their side back to `close`, that hasn't been released yet).

The other change is reworking the pool get code to be more direct. It tries to get a pool connection if one exists but if not it doesn't block and just makes a new one. This means that there can be more than the maxsize of connections, but it will never block. This feels like the more correct behavior to me as a spike of DB connections is generally preferable to a website or worker queue locking up under load :) It might be good to switch the put to a nowait as well, for the same reason.