### PR TITLE
Support django 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,24 @@ matrix:
     - {env: DJANGO=1.11, python: '3.6'}
     - {env: DJANGO=1.11, python: '3.7'}
     - {env: DJANGO=1.11, python: '3.8'}
-    - {env: DJANGO=1.11, python: 'pypy2.7-6.0'}
-    - {env: DJANGO=1.11, python: 'pypy3.5-6.0'}
+    - {env: DJANGO=1.11, python: 'pypy3'}
 
     - {env: DJANGO=2.2, python: '3.5'}
     - {env: DJANGO=2.2, python: '3.6'}
     - {env: DJANGO=2.2, python: '3.7'}
     - {env: DJANGO=2.2, python: '3.8'}
     - {env: DJANGO=2.2, python: 'nightly'}
-    - {env: DJANGO=2.2, python: 'pypy3.5-6.0'}
+    - {env: DJANGO=2.2, python: 'pypy3'}
+
+    - {env: DJANGO=3.0, python: '3.6'}
+    - {env: DJANGO=3.0, python: '3.7'}
+    - {env: DJANGO=3.0, python: '3.8'}
+    - {env: DJANGO=3.0, python: 'nightly'}
+    - {env: DJANGO=3.0, python: 'pypy3'}
 
     - {env: DJANGO=master, python: '3.6'}
     - {env: DJANGO=master, python: '3.7'}
-    - {env: DJANGO=master, python: '3.7'}
+    - {env: DJANGO=master, python: '3.8'}
     - {env: DJANGO=master, python: 'nightly'}
 
   allow_failures:

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,10 +1,8 @@
 # coding=utf-8
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class TestModel(models.Model):
     data = models.CharField(max_length=32, blank=True)
 


### PR DESCRIPTION
Django 3 tests are failing because `python_2_unicode_compatible` is no longer available.