### PR TITLE
Fix TypeError on JSONField from Django 3.1.1

### DIFF
--- a/django_db_geventpool/backends/postgresql_psycopg2/base.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/base.py
@@ -5,6 +5,7 @@ import sys
 
 try:
     import psycopg2.extensions
+    import psycopg2.extras
 except ImportError as e:
     from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured("Error loading psycopg2 module: %s" % e)
@@ -47,6 +48,8 @@ class DatabaseWrapperMixin(object):
     def get_new_connection(self, conn_params):
         if self.connection is None:
             self.connection = self.pool.get()
+            # Fixes TypeError for models with JSONField introduced in Django 3.1.1
+            psycopg2.extras.register_default_jsonb(conn_or_curs=self.connection, loads=lambda x: x)
             self.closed_in_transaction = False
         return self.connection
 


### PR DESCRIPTION
I started seeing type errors for models with JSON fields after upgrading to Django 3.1.1. It looks like this is related to a [bug fix](https://docs.djangoproject.com/en/3.1/releases/3.1.1/#bugfixes) in that release that changed how JSON fields are handled related to `JSONField` and `order_by`. This fix adds the same change that Django does in `get_new_connection` whenever a connection is first loaded from the pool.

Let me know if there's anything I should change, thanks for maintaining this!