### PR TITLE
Fix loading of json fields with Django 3.1

### DIFF
--- a/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
@@ -16,6 +16,7 @@ except ImportError:
 
 try:
     from psycopg2 import connect, DatabaseError
+    import psycopg2.extras
 except ImportError as e:
     from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured("Error loading psycopg2 module: %s" % e)
@@ -111,6 +112,7 @@ class PostgresConnectionPool(DatabaseConnectionPool):
         conn = self.connect(*self.args, **self.kwargs)
         # set correct encoding
         conn.set_client_encoding('UTF8')
+        psycopg2.extras.register_default_jsonb(conn_or_curs=conn, loads=lambda x: x)
         return conn
 
     def check_usable(self, connection):


### PR DESCRIPTION
Django 3.1 seems to need [this line](https://github.com/django/django/blob/3.1.1/django/db/backends/postgresql/base.py#L206) when creating a new database connection, as otherwise JSON data isn't returned as a string from the database (which is needed to work properly with the bundled `JSONField`).