### PR TITLE
Fixed TypeError when using with JSONField

### DIFF
--- a/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
@@ -16,6 +16,7 @@ except ImportError:
 
 try:
     from psycopg2 import connect, DatabaseError
+    from psycopg2.extras import register_default_jsonb
 except ImportError as e:
     from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured("Error loading psycopg2 module: %s" % e)
@@ -111,6 +112,7 @@ class PostgresConnectionPool(DatabaseConnectionPool):
         conn = self.connect(*self.args, **self.kwargs)
         # set correct encoding
         conn.set_client_encoding('UTF8')
+        register_default_jsonb(conn_or_curs=conn, loads=lambda x: x)
         return conn
 
     def check_usable(self, connection):


### PR DESCRIPTION
When using a JSONField, I was getting the following traceback:
```
File "C:\Users\roushik\Documents\PycharmProjects\venv\lib\site-packages\django\db\models\query.py", line 425, in get
    num = len(clone)
  File "C:\Users\roushik\Documents\PycharmProjects\venv\lib\site-packages\django\db\models\query.py", line 269, in __len__
    self._fetch_all()
  File "C:\Users\roushik\Documents\PycharmProjects\venv\lib\site-packages\django\db\models\query.py", line 1303, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "C:\Users\roushik\Documents\PycharmProjects\venv\lib\site-packages\django\db\models\query.py", line 70, in __iter__
    for row in compiler.results_iter(results):
  File "C:\Users\roushik\Documents\PycharmProjects\venv\lib\site-packages\django\db\models\sql\compiler.py", line 1100, in apply_converters
    value = converter(value, expression, connection)
  File "C:\Users\roushik\Documents\PycharmProjects\venv\lib\site-packages\django\db\models\fields\json.py", line 74, in from_db_value
    return json.loads(value, cls=self.decoder)
  File "C:\Users\roushik\miniconda3\lib\json\__init__.py", line 341, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
```

After a lot of digging I found this code block in `get_new_connection()` of  `site-packages\django\db\backends\postgresql\base.py` (line 203):
```
# Register dummy loads() to avoid a round trip from psycopg2's decode
# to json.dumps() to json.loads(), when using a custom decoder in
# JSONField.
psycopg2.extras.register_default_jsonb(conn_or_curs=connection, loads=lambda x: x)
```

This was missing in the current implementation of `create_connection()` in `psycopg2_pool.py`
I've added this line to the `create_connection()` method

