### PR TITLE
Add testing with tox and demonstrate Django 2.2 JSONField bug

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -1,10 +1,12 @@
 # coding=utf-8
 
 from django.db import models
+from django.contrib.postgres.fields import JSONField
 
 
 class TestModel(models.Model):
-    data = models.CharField(max_length=32, blank=True)
+    charfield = models.CharField(max_length=32, blank=True)
+    jsonfield = JSONField(default=dict)
 
     def __str__(self):
         return str(self.pk)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -23,15 +23,18 @@ def test_multiple_connections(count):
 class ModelTest(TestCase):
     databases = {'default'}
     def test_model_save(self):
+        data = {
+            'charfield': 'testing save',
+            'jsonfield': {'test': 'value'},
+        }
+        pk = TestModel.objects.create(**data).pk
 
-        data = 'testing save'
-        obj = TestModel.objects.create(data=data)
-
-        obj2 = TestModel.objects.get(pk=obj.pk)
-        self.assertEqual(obj.data, obj2.data)
+        obj = TestModel.objects.get(pk=pk)
+        for key in data.keys():
+            self.assertEqual(data[key], getattr(obj, key))
 
     def test_connections(self):
-        TestModel.objects.create(data='test')
+        TestModel.objects.create()
         greenlets = []
 
         for x in range(0, 50):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27-dj11,py{36,37,38}-dj{11,22,30,31}
+
+[testenv]
+commands = python -Wall runtests.py
+deps =
+  gevent
+  psycopg2-binary
+  dj11: django~=1.1
+  dj22: django~=2.2
+  dj30: django~=3.0
+  dj31: django~=3.1


### PR DESCRIPTION
- relates to #53 (JSONField returns string with Django 2.2)
- I'd recommend merging this to `master` and and reverting 6f5c43f6f3a2887e14de0e4ed02ec809352c5f4c in a `3.2.x` branch followed by a new 3.2.4 release for everyone on the Django LTS
- then remove Django 1.11 & 2.2 from the tox testing matrix, update the `Framework` & `Language` classifiers, `install_requires` and add [`python_requires`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires) in `setup.py` and do a 3.3.0 release with only Django 3.x support for those living on the edge ;)