### PR TITLE
Updated JSONField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.4
+
+- Changed JSONField to come from `django.db.models` instead of the removed (as of Django 4.0) `django.contrib.postgres.fields`, @veracrux
+
 ## 3.2.3
 
 - Fixed TypeError when using JSONField with Django 3.1, @bvallant
@@ -25,7 +29,6 @@
 ## 3.0.0
 
 - psycopg2 is not installed by default, @mattbriancon
-
 
 ## 2
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,12 +1,11 @@
 # coding=utf-8
 
 from django.db import models
-from django.contrib.postgres.fields import JSONField
 
 
 class TestModel(models.Model):
     charfield = models.CharField(max_length=32, blank=True)
-    jsonfield = JSONField(default=dict)
+    jsonfield = models.JSONField(default=dict)
 
     def __str__(self):
         return str(self.pk)


### PR DESCRIPTION
Changed JSONField to come from `django.db.models` instead of the removed (as of Django 4.0) `django.contrib.postgres.fields`