### PR TITLE
feat: log error when using all connections

### DIFF
--- a/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
+++ b/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py
@@ -55,7 +55,10 @@ class DatabaseConnectionPool(object):
 
     def get(self):
         try:
-            if self.size >= self.maxsize or self.pool.qsize():
+            size = self.size 
+            if size == self.maxsize:
+                logger.error('All %s database connections used. Waiting', self.maxsize)
+            if size >= self.maxsize or self.pool.qsize():
                 conn = self.pool.get()
             else:
                 conn = self.pool.get_nowait()


### PR DESCRIPTION
This may be followed up by something customisable, but for now, this gives an idea of how much this happens, especially if this ends up getting logged to Sentry.