### PR TITLE
fix: pin ubuntu to version 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,28 +15,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.6'
             django-version: '3.2.13'
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.7'
             django-version: '3.2.13'
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.8'
             django-version: '3.2.13'
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.9'
             django-version: '3.2.13'
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.10'
             django-version: '3.2.13'
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: 'pypy3'
             django-version: '3.2.13'
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.9'
             django-version: '4.0.4'
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.10'
             django-version: '4.0.4'
     services:


### PR DESCRIPTION
Newer versions do not have python 3.6 so pinning is necessary for tests