### PR TITLE
Fix PostGIS backend

### DIFF
--- a/django_db_geventpool/backends/postgis/base.py
+++ b/django_db_geventpool/backends/postgis/base.py
@@ -3,12 +3,17 @@ from django.contrib.gis.db.backends.postgis.base import (
 )
 
 try:
+    # try psycopg3
     import psycopg  # noqa
-    from ..postgresql_psycopg3.base import DatabaseWrapperMixin
+    INTRANS = psycopg.pq.TransactionStatus.INTRANS
+    from ..postgresql_psycopg3.base import base, PostgresConnectionPool
 except ImportError:
-    # fallback to psycopg3
-    from ..postgresql_psycopg2.base import DatabaseWrapperMixin
+    # fallback to psycopg2
+    import psycopg2
+    INTRANS = psycopg2.extensions.TRANSACTION_STATUS_INTRANS
+    from ..postgresql_psycopg2.base import base, PostgresConnectionPool
 
 
-class DatabaseWrapper(DatabaseWrapperMixin, OriginalDatabaseWrapper):
-    pass
+class DatabaseWrapper(base.DatabaseWrapperMixin, OriginalDatabaseWrapper):
+    pool_class = PostgresConnectionPool
+    INTRANS = INTRANS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgis/postgis:13-3.2-alpine
+    shm_size: 128mb
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    expose:
+      - 5432
+    ports:
+      - '127.0.0.1:5432:5432'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ authors = [
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.1",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/runtests_psycopg2_gis.py
+++ b/runtests_psycopg2_gis.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+import sys
+import gevent.monkey
+
+gevent.monkey.patch_all()
+
+try:
+    from psycopg2cffi import compat
+
+    compat.register()
+except ImportError:
+    pass
+
+import psycogreen.gevent
+
+psycogreen.gevent.patch_psycopg()
+
+import django
+from django.conf import settings
+from django.test.runner import DiscoverRunner
+
+
+settings.configure(
+    DEBUG=True,
+    DATABASES={
+        "default": {
+            "ENGINE": "django_db_geventpool.backends.postgis",
+            "NAME": "test",
+            "USER": "postgres",
+            "PASSWORD": "postgres",
+            "ATOMIC_REQUESTS": False,
+            "CONN_MAX_AGE": 0,
+            "HOST": "localhost",
+        }
+    },
+    INSTALLED_APPS=(
+        "tests",
+        "django_db_geventpool",
+    ),
+    USE_TZ=True,
+)
+django.setup()
+
+test_runner = DiscoverRunner(verbosity=2)
+
+failures = test_runner.run_tests(["tests"])
+if failures:
+    sys.exit(failures)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+
+[tox]
+envlist =
+  py3{8,9,10,11,12}-dj{32,42}-pg{is,2}
+  py3{8,9,10,11,12}-dj{42}-pg{3}
+  py3{10,11,12}-dj{50}-pg{is,2,3}
+
+[testenv]
+deps =
+  gevent
+  psycogreen
+  dj32: django~=3.2
+  dj42: django~=4.2
+  dj50: django~=5.0
+  pgis: psycopg2-binary
+  pg2: psycopg2-binary
+  pg3: psycopg[binary,pool]
+
+commands =
+  pgis: python -Wall runtests_psycopg2_gis.py
+  pg2: python -Wall runtests_psycopg2.py
+  pg3: python -Wall runtests_psycopg3.py


### PR DESCRIPTION
Using `'django_db_geventpool.backends.postgis'` as `BACKEND` leads to an `ImportError`:

```
ImportError: cannot import name 'DatabaseWrapperMixin' from 'django_db_geventpool.backends.postgresql_psycopg2.base' (/venv/lib/python3.9/site-packages/django_db_geventpool/backends/postgresql_psycopg2/base.py)
```

This PR fixes this.

If you do not want any tox/docker files in the repo, please just cherry-pick b81892c8e8f8d9ff261d5ff9c272b846d8814251 and maybe bb00e74a218736a7d3f016c82694614a1406b7e2