### PR TITLE
adjust DatabaseWrapperMixin to make sure the base get_new_connection is called when creating a new connection

### DIFF
--- a/django_db_geventpool/backends/base.py
+++ b/django_db_geventpool/backends/base.py
@@ -30,7 +30,7 @@ class DatabaseWrapperMixin(object):
             return self._pool
         with connection_pools_lock:
             if self.alias not in connection_pools:
-                self._pool = self.pool_class(**self.get_connection_params())
+                self._pool = self.pool_class(super(), **self.get_connection_params(), connect=lambda parent, **kw: parent.get_new_connection(conn_params=kw))
                 connection_pools[self.alias] = self._pool
             else:
                 self._pool = connection_pools[self.alias]

--- a/runtests_psycopg2.py
+++ b/runtests_psycopg2.py
@@ -43,6 +43,6 @@ django.setup()
 
 test_runner = DiscoverRunner(verbosity=2)
 
-failures = test_runner.run_tests(["tests"])
+failures = test_runner.run_tests(["tests.tests"])
 if failures:
     sys.exit(failures)

--- a/runtests_psycopg2_gis.py
+++ b/runtests_psycopg2_gis.py
@@ -43,6 +43,6 @@ django.setup()
 
 test_runner = DiscoverRunner(verbosity=2)
 
-failures = test_runner.run_tests(["tests"])
+failures = test_runner.run_tests(["tests.tests", "tests.tests_gis"])
 if failures:
     sys.exit(failures)

--- a/runtests_psycopg3.py
+++ b/runtests_psycopg3.py
@@ -32,6 +32,6 @@ django.setup()
 
 test_runner = DiscoverRunner(verbosity=2)
 
-failures = test_runner.run_tests(["tests"])
+failures = test_runner.run_tests(["tests.tests"])
 if failures:
     sys.exit(failures)

--- a/runtests_psycopg3_gis.py
+++ b/runtests_psycopg3_gis.py
@@ -32,6 +32,6 @@ django.setup()
 
 test_runner = DiscoverRunner(verbosity=2)
 
-failures = test_runner.run_tests(["tests"])
+failures = test_runner.run_tests(["tests.tests", "tests.tests_gis"])
 if failures:
     sys.exit(failures)

--- a/tox.ini
+++ b/tox.ini
@@ -27,5 +27,5 @@ deps =
 commands =
   pg2-gis: python -Wall runtests_psycopg2_gis.py
   pg2: python -Wall runtests_psycopg2.py
-  pg3-gis:python -Wall runtests_psycopg3_gis.py
+  pg3-gis: python -Wall runtests_psycopg3_gis.py
   pg3: python -Wall runtests_psycopg3.py


### PR DESCRIPTION
This is needed for psycopg3 because the base postgis DatabaseWrapper from django registers geometry adapters in the get_new_connection call